### PR TITLE
Removed obsolete browserExtActionId parameter

### DIFF
--- a/index.html
+++ b/index.html
@@ -3243,7 +3243,7 @@ Patterns listed in <code>&lt;url-pattern&gt;</code> allow additional permissions
                                 </tr>
                                 <tr>
                                     <td>POST</td>
-                                    <td id="take-browser-extension-action">/session/{<var>sessionId</var>}/browserext/action/{<var>browserExtActionId</var>}</td>
+                                    <td id="take-browser-extension-action">/session/{<var>sessionId</var>}/browserext/action/</td>
                                     <td></td>
                                 </tr>
                             </tbody>


### PR DESCRIPTION
This was left over from when browserExtActions used to have IDs. These were removed in favor of `extensionActionTypes`, so I've removed this accordingly.